### PR TITLE
adding language string for premission block view

### DIFF
--- a/lang/en/block_cmanager.php
+++ b/lang/en/block_cmanager.php
@@ -108,7 +108,7 @@ $string['email_noReplyInstructions'] = 'This utility sends email requests to adm
 $string['norequestcontrol'] = 'Disable request control';
 $string['norequestcontrol_desc'] = 'Check this box to disable the option to disable the option to request control of an existing course.';
 
-//email subjects and contents
+//email subjects and contentsfcm
 $string['emailSubj_userApproved'] = "Moodle request approved!";
 $string['emailSubj_adminApproved'] = "Moodle user request approved!";
 $string['emailSubj_adminNewRequest'] = "New Moodle request";
@@ -448,7 +448,7 @@ $string['cmanager:denyrecord'] = 'Deny record';
 $string['cmanager:editrecord'] = 'Edit record';
 $string['cmanager:viewrecord'] = 'View record';
 $string['cmanager:viewconfig'] = 'View config';
-$string['cmanager:cmmanager:view'] = 'View block';
+$string['cmanager:cmanager:view'] = 'View block';
 
 $string['ok'] = 'Ok';
 $string['lib_error_invalid_c'] = 'Invalid course ID!';

--- a/lang/en/block_cmanager.php
+++ b/lang/en/block_cmanager.php
@@ -448,6 +448,7 @@ $string['cmanager:denyrecord'] = 'Deny record';
 $string['cmanager:editrecord'] = 'Edit record';
 $string['cmanager:viewrecord'] = 'View record';
 $string['cmanager:viewconfig'] = 'View config';
+$string['cmanager:cmmanager:view'] = 'View block';
 
 $string['ok'] = 'Ok';
 $string['lib_error_invalid_c'] = 'Invalid course ID!';

--- a/lang/en/block_cmanager.php
+++ b/lang/en/block_cmanager.php
@@ -448,7 +448,7 @@ $string['cmanager:denyrecord'] = 'Deny record';
 $string['cmanager:editrecord'] = 'Edit record';
 $string['cmanager:viewrecord'] = 'View record';
 $string['cmanager:viewconfig'] = 'View config';
-$string['cmanager:cmanager:view'] = 'View block';
+$string['cmanager:view'] = 'View block';
 
 $string['ok'] = 'Ok';
 $string['lib_error_invalid_c'] = 'Invalid course ID!';

--- a/version.php
+++ b/version.php
@@ -27,7 +27,7 @@
 
 defined('MOODLE_INTERNAL') || die();
 
-$plugin->version   = 2022012300;      // The current module version (Date: YYYYMMDDXX)
+$plugin->version   = 2022072100;      // The current module version (Date: YYYYMMDDXX)
 $plugin->requires  = 2019052000;      // Requires Moodle 3.7 or later.
 $plugin->component = 'block_cmanager';
 $plugin->maturity = MATURITY_BETA;


### PR DESCRIPTION
@michael-milette when I installed the block I noticed a language string was missing from the premissions page. Fixed the issue and bumped the version. 